### PR TITLE
Standardize on preferring const except where mutation is necessary

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
   'rules': {
     'arrow-body-style': ['error', 'as-needed'],
     'no-shadow': 'error', // shadowing is an easy way to let babel/webpack make mistakes
+    'prefer-const': 'error',
     'semi': ['error', 'never'],
     'space-before-function-paren': ['error', {
       'anonymous': 'never',


### PR DESCRIPTION
...and we should really consider if there's a way to refactor those cases to avoid mutation.

[`prefer-const` documentation](https://eslint.org/docs/rules/prefer-const)

As a bonus, this is auto-fixable so should be easy to roll out!

I'd like to see us move more of our rules to the common config as they make sense.