### PR TITLE
hon2a/separated

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ use the provided additional config extensions.
 
 The following extensions are provided:
 
-- `cypress` - for applications that use Cypress for end-to-end testing,
+- `cypress` - for applications that use Cypress for end-to-end testing **(requires `eslint-plugin-cypress`)**,
 - `jest` - for any project using Jest for unit testing,
-- `react` - for applications or component libraries using React (requires `eslint-plugin-react`!),
+- `react` - for applications or component libraries using React **(requires `eslint-plugin-react`)**,
 - `enzyme` - for applications or component libraries that use Enzyme for testing React components,
 - `quadro-application` - for applications built with the `quadro` framework.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,37 @@
 # eslint-config
 
-Eslint configurations used by Wiser Solutions, Inc.:
+Baseline ESLint configurations used by Wiser Solutions, Inc.
 
-- basic configuration (`extend: '@wisersolutions'`)
-- extended configurations for:
-    - packages using `jest`: `extend: '@wisersolutions/eslint-config/jest'`
-    - packages using `jest` & `jest-enzyme`: `extend: '@wisersolutions/eslint-config/jest-enzyme'`
-    - `quadro` apps (`extend: '@wisersolutions/eslint-config/quadro'`)
+### Base Config
+
+Every JavaScript project should start by extending the base config.
+
+```json
+{
+  "extends": "@wisersolutions"
+}
+```
+
+### Extensions
+
+In some specific use-cases (e.g. application projects) or when using some common libraries (e.g. `jest`),
+use the provided additional config extensions.
+
+```json
+{
+  "extends": [
+    "@wisersolutions",
+    "@wisersolutions/eslint-config/jest",
+    "@wisersolutions/eslint-config/cypress",
+    "…"
+  ]
+}
+```
+
+The following extensions are provided:
+
+- `cypress` - for applications that use Cypress for end-to-end testing,
+- `jest` - for any project using Jest for unit testing,
+- `react` - for applications or component libraries using React,
+- `enzyme` - for applications or component libraries that use Enzyme for testing React components,
+- `quadro-application` - for applications built with the `quadro` framework.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following extensions are provided:
 
 - `cypress` - for applications that use Cypress for end-to-end testing,
 - `jest` - for any project using Jest for unit testing,
-- `react` - for applications or component libraries using React,
+- `react` - for applications or component libraries using React (requires `eslint-plugin-react`!),
 - `enzyme` - for applications or component libraries that use Enzyme for testing React components,
 - `quadro-application` - for applications built with the `quadro` framework.
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,18 @@ The following extensions are provided:
 - `react` - for applications or component libraries using React,
 - `enzyme` - for applications or component libraries that use Enzyme for testing React components,
 - `quadro-application` - for applications built with the `quadro` framework.
+
+### Combinations
+
+There are also combinations provides to simplify the most common use-cases.
+
+```json
+{
+  "extend": "@wisersolutions/eslint-config/application"
+}
+```
+
+The following combinations are provided:
+
+- `application` - applications using React, Cypress, and Jest,
+- `quadro-application` - applications built with the Quadro framework (plus all of the above).

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ use the provided additional config extensions.
 The following extensions are provided:
 
 - `cypress` - for applications that use Cypress for end-to-end testing **(requires `eslint-plugin-cypress`)**,
-- `jest` - for any project using Jest for unit testing,
+- `jest` - for any project using Jest for unit testing **(requires `eslint-plugin-jest`)**,
 - `react` - for applications or component libraries using React **(requires `eslint-plugin-react`)**,
-- `enzyme` - for applications or component libraries that use Enzyme for testing React components,
-- `quadro-application` - for applications built with the `quadro` framework.
+- `enzyme` - for applications or component libraries that use Enzyme for testing React components.
 
 ### Combinations
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Every JavaScript project should start by extending the base config.
 }
 ```
 
+**Note:** The base config requires the `babel-eslint` parser installed.
+
 ### Extensions
 
 In some specific use-cases (e.g. application projects) or when using some common libraries (e.g. `jest`),

--- a/application.js
+++ b/application.js
@@ -1,0 +1,8 @@
+module.exports = {
+  'extends': [
+    '@wisersolutions',
+    '@wisersolutions/eslint-config/react',
+    '@wisersolutions/eslint-config/jest',
+    '@wisersolutions/eslint-config/cypress'
+  ]
+}

--- a/application.js
+++ b/application.js
@@ -1,8 +1,16 @@
 module.exports = {
   'extends': [
     '@wisersolutions',
-    '@wisersolutions/eslint-config/react',
-    '@wisersolutions/eslint-config/jest',
-    '@wisersolutions/eslint-config/cypress'
+    '@wisersolutions/eslint-config/react'
+  ],
+  'overrides': [
+    {
+      'files': ['cypress/**/*'],
+      'extends': '@wisersolutions/eslint-config/cypress'
+    },
+    {
+      'files': ['!cypress/**/*'],
+      'extends': '@wisersolutions/eslint-config/jest'
+    }
   ]
 }

--- a/cypress.js
+++ b/cypress.js
@@ -1,15 +1,3 @@
 module.exports = {
-  'overrides': [
-    {
-      'files': ['cypress/**/*.*'],
-      'env': {
-        'jasmine': true,
-        'mocha': true
-      },
-      'globals': {
-        'Cypress': true,
-        'cy': true
-      }
-    }
-  ]
+  'extends': 'plugin:cypress/recommended'
 }

--- a/cypress.js
+++ b/cypress.js
@@ -1,0 +1,15 @@
+module.exports = {
+  'overrides': [
+    {
+      'files': ['cypress/**/*.*'],
+      'env': {
+        'jasmine': true,
+        'mocha': true
+      },
+      'globals': {
+        'Cypress': true,
+        'cy': true
+      }
+    }
+  ]
+}

--- a/enzyme.js
+++ b/enzyme.js
@@ -1,8 +1,4 @@
-const merge = require('lodash.merge')
-
-const baseConfig = require('./jest')
-
-module.exports = merge({}, baseConfig, {
+module.exports = {
   'overrides': [
     {
       'files': ['**/*.test.js'],
@@ -14,4 +10,4 @@ module.exports = merge({}, baseConfig, {
       }
     }
   ]
-})
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   'extends': [
     'eslint:recommended',
-    'plugin:react/recommended',
     'prettier'
   ],
   'parserOptions': {

--- a/jest.js
+++ b/jest.js
@@ -1,8 +1,4 @@
-const merge = require('lodash.merge')
-
-const baseConfig = require('./index')
-
-module.exports = merge({}, baseConfig, {
+module.exports = {
   'overrides': [
     {
       'files': ['**/*.test.js'],
@@ -11,4 +7,4 @@ module.exports = merge({}, baseConfig, {
       }
     }
   ]
-})
+}

--- a/jest.js
+++ b/jest.js
@@ -1,10 +1,9 @@
 module.exports = {
-  'overrides': [
-    {
-      'files': ['**/*.test.js'],
-      'env': {
-        'jest': true
-      }
-    }
-  ]
+  'extends': [
+    'plugin:jest/recommended',
+    'plugin:jest/style'
+  ],
+  'rules': {
+    'jest/expect-expect': 'off' // doesn't support helpers that perform the assertions internally (e.g. `checkSnapshot`)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "peerDependencies": {
     "eslint": ">=6",
     "eslint-config-prettier": ">=6",
-    "eslint-plugin-react": ">=7",
     "babel-eslint": ">=10"
   }
 }

--- a/quadro-application.js
+++ b/quadro-application.js
@@ -1,8 +1,4 @@
-const merge = require('lodash.merge')
-
-const baseConfig = require('./index')
-
-module.exports = merge({}, baseConfig, {
+module.exports = {
   'globals': {
     'Q': true
   },
@@ -24,17 +20,6 @@ module.exports = merge({}, baseConfig, {
       }
     },
     {
-      'files': ['cypress/**/*.*'],
-      'env': {
-        'jasmine': true,
-        'mocha': true
-      },
-      'globals': {
-        'Cypress': true,
-        'cy': true
-      }
-    },
-    {
       'files': ['test/**/*.*'],
       'env': {
         'mocha': true
@@ -47,4 +32,4 @@ module.exports = merge({}, baseConfig, {
       }
     }
   ]
-})
+}

--- a/quadro-application.js
+++ b/quadro-application.js
@@ -1,4 +1,9 @@
 module.exports = {
+  'extends': [
+    '@wisersolutions',
+    '@wisersolutions/eslint-config/react',
+    '@wisersolutions/eslint-config/cypress'
+  ],
   'globals': {
     'Q': true
   },

--- a/quadro-application.js
+++ b/quadro-application.js
@@ -1,13 +1,16 @@
 module.exports = {
   'extends': [
     '@wisersolutions',
-    '@wisersolutions/eslint-config/react',
-    '@wisersolutions/eslint-config/cypress'
+    '@wisersolutions/eslint-config/react'
   ],
   'globals': {
     'Q': true
   },
   'overrides': [
+    {
+      'files': ['cypress/**/*'],
+      'extends': '@wisersolutions/eslint-config/cypress'
+    },
     {
       'files': ['client/**/*.*'],
       'env': {
@@ -17,9 +20,7 @@ module.exports = {
     },
     {
       'files': ['client/**/*.test.js', 'client/test/**/*.*'],
-      'env': {
-        'jest': true
-      },
+      'extends': '@wisersolutions/eslint-config/jest',
       'rules': {
         'no-sparse-arrays': 'off'
       }

--- a/react.js
+++ b/react.js
@@ -1,0 +1,3 @@
+module.exports = {
+  'extends': 'plugin:react/recommended'
+}


### PR DESCRIPTION
Complete refactoring to produce independent config bits rather than assumptions about how they'll be combined … and then some common combinations as an additional sugar.

_This was prompted by @SaladFork's note that including `react` in the base config makes it unusable for non-application packages._

**A new major version will be released after this is merged.**